### PR TITLE
storing input values without prior necessity of focus loss

### DIFF
--- a/webview-ui/src/Common.tsx
+++ b/webview-ui/src/Common.tsx
@@ -26,7 +26,7 @@ function Common({ disabled, error }: CommonProps) {
           <VSCodeTextField
             value={id}
             disabled={disabled}
-            onChange={(e) => {
+            onInput={(e) => {
               const target = e.target as HTMLInputElement;
               if (target) {
                 setId(target.value);

--- a/webview-ui/src/PostgreSql.tsx
+++ b/webview-ui/src/PostgreSql.tsx
@@ -74,7 +74,7 @@ function PostgreSql({ error, inProgress, submitData }: PostgreSqlProps) {
             <VSCodeTextField
               value={host}
               disabled={inProgress}
-              onChange={(e) => {
+              onInput={(e) => {
                 const target = e.target as HTMLInputElement;
                 if (target) {
                   setHost(target.value);
@@ -88,7 +88,7 @@ function PostgreSql({ error, inProgress, submitData }: PostgreSqlProps) {
             <VSCodeTextField
               value={database}
               disabled={inProgress}
-              onChange={(e) => {
+              onInput={(e) => {
                 const target = e.target as HTMLInputElement;
                 if (target) {
                   setDatabase(target.value);
@@ -102,7 +102,7 @@ function PostgreSql({ error, inProgress, submitData }: PostgreSqlProps) {
             <VSCodeTextField
               value={user}
               disabled={inProgress}
-              onChange={(e) => {
+              onInput={(e) => {
                 const target = e.target as HTMLInputElement;
                 if (target) {
                   setUser(target.value);
@@ -116,7 +116,7 @@ function PostgreSql({ error, inProgress, submitData }: PostgreSqlProps) {
             <VSCodeTextField
               value={password}
               disabled={inProgress}
-              onChange={(e) => {
+              onInput={(e) => {
                 const target = e.target as HTMLInputElement;
                 if (target) {
                   setPassword(target.value);

--- a/webview-ui/src/Wfs.tsx
+++ b/webview-ui/src/Wfs.tsx
@@ -86,7 +86,7 @@ function Wfs({ submitData, inProgress, error }: PostgreSqlProps) {
             <VSCodeTextField
               value={url ? url : undefined || ""}
               disabled={inProgress}
-              onChange={(e) => {
+              onInput={(e) => {
                 const target = e.target as HTMLInputElement;
                 if (target) {
                   setUrl(target.value);
@@ -114,7 +114,7 @@ function Wfs({ submitData, inProgress, error }: PostgreSqlProps) {
                 <VSCodeTextField
                   value={user ? user : undefined || ""}
                   disabled={inProgress}
-                  onChange={(e) => {
+                  onInput={(e) => {
                     const target = e.target as HTMLInputElement;
                     if (target) {
                       setUser(target.value);
@@ -128,7 +128,7 @@ function Wfs({ submitData, inProgress, error }: PostgreSqlProps) {
                 <VSCodeTextField
                   value={password ? password : undefined || ""}
                   disabled={inProgress}
-                  onChange={(e) => {
+                  onInput={(e) => {
                     const target = e.target as HTMLInputElement;
                     if (target) {
                       setPassword(target.value);


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on a PR over several days, please create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.
-->

### Changes introduced by this PR

<!--
    Either reference the issue(s) that describe the changes introduced by this PR 
-->

When creating a configuration and still within a TextField, the field value is being saved now when switching tabs within the extension.

<!--
    or shortly describe the changes below using bullet points
-->

